### PR TITLE
Update GetMenu.php

### DIFF
--- a/app/Http/Middleware/GetMenu.php
+++ b/app/Http/Middleware/GetMenu.php
@@ -40,7 +40,7 @@ class GetMenu
         //查找出所有的地址
         $table = Cache::store('file')->rememberForever('menus', function () {
             return \App\Models\Admin\Permission::where('name', 'LIKE', '%index')
-                ->orWhere('cid', '==', 0)
+                ->orWhere('cid', '=', 0)
                 ->get();
         });
         foreach ($table as $v) {


### PR DESCRIPTION
*测试环境
Windows10 pro
PHP 7.0.13 (cli) (built: Nov  8 2016 13:45:28) ( ZTS )
Sqlite

*问题描述
左侧的目录无法正常显示

*修改意见
把orWhere的操作符'=='改为'='